### PR TITLE
Fix: delete role property from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ To get started, clone the repo:
    | sdkKey                   | Required, your Zoom Meeting SDK Key or Client ID for Meeting SDK app type's created after February 11, 2023. [You can get yours here](https://marketplace.zoom.us/develop/create). |
    | meetingNumber                   | Required, the Zoom Meeting or webinar number. |
    | passWord                   | Optional, meeting password. Leave as empty string if the meeting does not require a password. |
-   | role                   | Required, `0` to specify participant, `1` to specify host. |
    | userName                   | Required, a name for the user joining / starting the meeting / webinar. |
    | userEmail                   | Required for Webinar, optional for Meeting, required for meeting and webinar if [registration is required]([registration](https://support.zoom.us/hc/en-us/articles/360054446052-Managing-meeting-and-webinar-registration)). The email of the user starting or joining the meeting / webinar. |
    | registrantToken            | Required if your [meeting](https://marketplace.zoom.us/docs/sdk/native-sdks/web/client-view/meetings#join-registered) or [webinar](https://marketplace.zoom.us/docs/sdk/native-sdks/web/client-view/webinars) requires [registration](https://support.zoom.us/hc/en-us/articles/360054446052-Managing-meeting-and-webinar-registration). |
@@ -54,7 +53,6 @@ To get started, clone the repo:
    var sdkKey = 'abc123'
    var meetingNumber = '123456789'
    var passWord = ''
-   var role = 0
    var userName = 'React'
    var userEmail = ''
    var registrantToken = ''


### PR DESCRIPTION
Hello Zoom team,

As far as I understand and being experienced with the API. Proving the role property causes the Meeting SDK to enter a state where it is not possible to join the meeting. The role property is not required and the Meeting SDK will automatically assign the role based on the token provided by the Auth endpoint.

I updated the README.md to reflect this, because it is confusing to have the role property in the example code and not have it work when I was trying to use the Meeting SDK.

Please let me know if the change makes sense.